### PR TITLE
Rewrite existing backend tests such that AWS dependencies are called directly

### DIFF
--- a/backend/schedule/__tests__/add_event.test.js
+++ b/backend/schedule/__tests__/add_event.test.js
@@ -9,8 +9,6 @@ const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'add_event' });
 
-const AWS = require('aws-sdk');
-
 const sample_event = {
   id: "1",
   category: "main",
@@ -26,7 +24,6 @@ describe('add_event', () => {
 
   it('Correctly inserts the event into the database', async () => {
     const bodyStub = sample_event;
-    const ddb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
 
     const event = {
       body: JSON.stringify(bodyStub)

--- a/backend/schedule/__tests__/add_event.test.js
+++ b/backend/schedule/__tests__/add_event.test.js
@@ -9,7 +9,7 @@ const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'add_event' });
 
-const AWS = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 
 const sample_event = {
   id: "1",
@@ -24,16 +24,14 @@ describe('add_event', () => {
     done();
   });
 
-  it('Correctly inserts the event into the database', () => {
+  it('Correctly inserts the event into the database', async () => {
     const bodyStub = sample_event;
-    AWS.mock('DynamoDB', 'putItem', function(params, callback) {
-      callback(null, {Item: sample_event});
-    });
+    const ddb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
 
     const event = {
       body: JSON.stringify(bodyStub)
     };
-    return wrapped.run(event).then((response) => {
+    return await wrapped.run(event).then(async (response) => {
       expect(response).toBeDefined();
       expect(response).toMatchObject({body: JSON.stringify(sample_event), statusCode: 200})
     });

--- a/backend/schedule/__tests__/add_event.test.js
+++ b/backend/schedule/__tests__/add_event.test.js
@@ -33,7 +33,7 @@ describe('add_event', () => {
     };
     return await wrapped.run(event).then(async (response) => {
       expect(response).toBeDefined();
-      expect(response).toMatchObject({body: JSON.stringify(sample_event), statusCode: 200})
+      expect(response).toMatchObject({body: {}, statusCode: 200})
     });
   });
 

--- a/backend/schedule/__tests__/add_event_to_user_list.test.js
+++ b/backend/schedule/__tests__/add_event_to_user_list.test.js
@@ -9,7 +9,7 @@ const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'add_event_to_user_list' });
 
-const AWS = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 
 const valid_case = {
   event_id: "5",
@@ -27,32 +27,26 @@ describe('add_event_to_user_list', () => {
 
   it('Correctly inserts the selection into the database', () => {
     const bodyStub = valid_case;
-    AWS.mock('DynamoDB', 'putItem', function(params, callback) {
-      callback(null, {Item: valid_case});
-    });
 
     const event = {
       body: JSON.stringify(bodyStub)
     };
     return wrapped.run(event).then((response) => {
       expect(response).toBeDefined();
-      expect(response).toHaveProperty('statusCode', 200);
+      expect(response).toMatchObject({body: {}, statusCode: 200});
       expect(JSON.parse(response.body)).toHaveProperty('id');
     });
   });
 
   it('Correctly fails if an invalid input is given', () => {
     const bodyStub = invalid_case;
-    AWS.mock('DynamoDB', 'putItem', function(params, callback) {
-      callback(null, {Item: invalid_case});
-    });
 
     const event = {
       body: JSON.stringify(bodyStub)
     };
     return wrapped.run(event).then((response) => {
       expect(response).toBeDefined();
-      expect(response).toHaveProperty('statusCode', 500);
+      expect(response).toMatchObject({body: {}, statusCode: 500});
     });
   });
 });

--- a/backend/schedule/__tests__/add_event_to_user_list.test.js
+++ b/backend/schedule/__tests__/add_event_to_user_list.test.js
@@ -9,8 +9,6 @@ const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'add_event_to_user_list' });
 
-const AWS = require('aws-sdk');
-
 const valid_case = {
   event_id: "5",
   user_id: "j32kg32v3-323j2"

--- a/backend/schedule/__tests__/get_event.test.js
+++ b/backend/schedule/__tests__/get_event.test.js
@@ -8,14 +8,14 @@ const mod = require('./../handler');
 const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'get_event' });
-const AWS = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 
 const sample_event = {
-  id: "1",
-  category: "main",
-  description: "A very cool workshop for Technica!",
-  start_time: "2020-6-5T15:00:00Z",
-  end_time: "2020-6-5T18:00:00Z",
+  category: { S: "main"},
+  start_time: { S: "2020-6-5T15:00:00Z"},
+  end_time: { S: "2020-6-5T18:00:00Z"},
+  description: { S: "A very cool workshop for Technica!"},
+  id: { S: "1"},
 }
 
 
@@ -29,9 +29,6 @@ describe('get_event', () => {
   };
 
   it('Correctly retrieves the event from the database', () => {
-    AWS.mock('DynamoDB', 'getItem', function(params, callback) {
-      callback(null, {Item: sample_event});
-    });
 
     return wrapped.run(event).then((response) => {
       expect(response).toBeDefined();

--- a/backend/schedule/__tests__/get_event.test.js
+++ b/backend/schedule/__tests__/get_event.test.js
@@ -8,7 +8,6 @@ const mod = require('./../handler');
 const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'get_event' });
-const AWS = require('aws-sdk');
 
 const sample_event = {
   category: { S: "main"},

--- a/backend/schedule/__tests__/get_event.test.js
+++ b/backend/schedule/__tests__/get_event.test.js
@@ -7,28 +7,53 @@ const mod = require('./../handler');
 
 const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
+const adder = lambdaWrapper.wrap(mod, { handler: 'add_event' });
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'get_event' });
+const AWS = require('aws-sdk');
 
-const sample_event = {
-  category: { S: "main"},
-  start_time: { S: "2020-6-5T15:00:00Z"},
-  end_time: { S: "2020-6-5T18:00:00Z"},
-  description: { S: "A very cool workshop for Technica!"},
-  id: { S: "1"},
+let sample_event = {
+  Item: {
+    category: { S: "main"},
+    start_time: { S: "2020-6-5T15:00:00Z"},
+    end_time: { S: "2020-6-5T18:00:00Z"},
+    description: { S: "A very cool workshop for Technica!"},
+    id: { S: "1"},
+  }
 }
 
+const insert_event = {
+  body: JSON.stringify({
+    id: "1",
+    category: "main",
+    description: "A very cool workshop for Technica!",
+    start_time: "2020-6-5T15:00:00Z",
+    end_time: "2020-6-5T18:00:00Z",
+  })
+}
+
+const params = {
+  TableName: process.env.SCHEDULE_TABLE,
+};
 
 describe('get_event', () => {
-  beforeAll((done) => {
+    beforeAll((done) => {
     done();
   });
 
-  const event = {
-    queryStringParameters: {id: 1}
-  };
+  it('Correctly retrieves the event from the database', async () => {
 
-  it('Correctly retrieves the event from the database', () => {
+    const ddb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
+      
+    let response2 = await adder.run(insert_event);
 
+    const result = await ddb.scan(params).promise();
+      
+    const event = {
+      queryStringParameters: {id: result.Items[0].id.S}
+    };
+
+    sample_event.Item.id = result.Items[0].id;
+      
     return wrapped.run(event).then((response) => {
       expect(response).toBeDefined();
       expect(response).toMatchObject({body: JSON.stringify(sample_event), statusCode: 200})

--- a/backend/schedule/__tests__/get_schedule.test.js
+++ b/backend/schedule/__tests__/get_schedule.test.js
@@ -15,7 +15,15 @@ const params = {
   TableName: process.env.SCHEDULE_TABLE,
 };
 
-const sample_event1 = {
+const sample_event = {
+    category: { S: "main"},
+    start_time: { S: "2020-6-5T15:00:00Z"},
+    end_time: { S: "2020-6-5T18:00:00Z"},
+    description: { S: "A very cool workshop for Technica!"},
+    id: { S: "1"},
+}
+
+const insert_event = {
   body: JSON.stringify({
     id: "1",
     category: "main",
@@ -25,19 +33,15 @@ const sample_event1 = {
   })
 }
 
-const sample_event2 = {
-  body: JSON.stringify({
-    id: "2",
-    category: "main",
-    description: "Another very cool workshop for Technica!",
-    start_time: "2020-6-5T15:00:00Z",
-    end_time: "2020-6-5T18:00:00Z",
-  })
-};
-
+const schedule_regex = new RegExp (
+  ['^(\\\[{\\\"category\\\":{\\\"S\\\":\\\".*\\\"},',
+   '\\\"start_time\\\":{\\\"S\\\":\\\".*\\\"},',
+   '\\\"end_time\\\":{\\\"S\\\":\\\".*\\\"},',
+   '\\\"description\\\":{\\\"S\\\":\\\".*\\\"},',
+   '\\\"id\\\":{\\\"S\\\":\\\".*\\\"}}\\\])+$'].join(''));
 
 describe('get_schedule', () => {
-  beforeAll(async (done) => {
+  beforeEach(async (done) => {
 
     const ddb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
 
@@ -55,18 +59,25 @@ describe('get_schedule', () => {
       let deletedItem = await ddb.deleteItem(deleteParams).promise()
 	
     });
-      
+
+    console.log("executing beforeEach()");
     done();
   });
 
   it('Correctly retrieves the schedule from the database', async () => {
 
-    let response = await adder.run(sample_event1);
-    response = await adder.run(sample_event2);
+    let response2 = await adder.run(insert_event);
       
     return wrapped.run().then((response) => {
       expect(response).toBeDefined();
-      expect(response).toMatchObject({body: {}, statusCode: 200})
+      expect(response).toMatchObject({
+          body: expect.stringMatching(schedule_regex),
+        statusCode: 200,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Credentials': true,
+        }
+      })
     });
   });
 });

--- a/backend/schedule/__tests__/get_schedule.test.js
+++ b/backend/schedule/__tests__/get_schedule.test.js
@@ -5,7 +5,6 @@
 
 const mod = require('./../handler');
 
-const AWS = require('aws-sdk');
 const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'get_schedule' });

--- a/backend/schedule/__tests__/get_schedule.test.js
+++ b/backend/schedule/__tests__/get_schedule.test.js
@@ -42,24 +42,6 @@ const schedule_regex = new RegExp (
 
 describe('get_schedule', () => {
   beforeEach(async (done) => {
-
-    const ddb = new AWS.DynamoDB({apiVersion: '2012-08-10'});
-
-    const result = await ddb.scan(params).promise();
-
-    result.Items.forEach(async (k) => {
-
-      let deleteParams = {
-	TableName: process.env.SCHEDULE_TABLE,
-	Key: {
-	  id: {S: k.id.S},
-	}
-      };
-	
-      let deletedItem = await ddb.deleteItem(deleteParams).promise()
-	
-    });
-
     done();
   });
 

--- a/backend/schedule/__tests__/get_schedule.test.js
+++ b/backend/schedule/__tests__/get_schedule.test.js
@@ -16,11 +16,11 @@ const params = {
 };
 
 const sample_event = {
-    category: { S: "main"},
-    start_time: { S: "2020-6-5T15:00:00Z"},
-    end_time: { S: "2020-6-5T18:00:00Z"},
-    description: { S: "A very cool workshop for Technica!"},
-    id: { S: "1"},
+  category: { S: "main"},
+  start_time: { S: "2020-6-5T15:00:00Z"},
+  end_time: { S: "2020-6-5T18:00:00Z"},
+  description: { S: "A very cool workshop for Technica!"},
+  id: { S: "1"},
 }
 
 const insert_event = {
@@ -60,7 +60,6 @@ describe('get_schedule', () => {
 	
     });
 
-    console.log("executing beforeEach()");
     done();
   });
 

--- a/backend/schedule/__tests__/get_schedule.test.js
+++ b/backend/schedule/__tests__/get_schedule.test.js
@@ -5,25 +5,25 @@
 
 const mod = require('./../handler');
 
-const AWS = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 const jestPlugin = require('serverless-jest-plugin');
 const lambdaWrapper = jestPlugin.lambdaWrapper;
 const wrapped = lambdaWrapper.wrap(mod, { handler: 'get_schedule' });
 
 const sample_schedule = [
   {
-    id: "1",
-    category: "main",
-    description: "A very cool workshop for Technica!",
-    start_time: "2020-6-5T15:00:00Z",
-    end_time: "2020-6-5T18:00:00Z",
+      id: {S: "1"},
+      category: {S: "main"},
+      description: {S: "A very cool workshop for Technica!"},
+      start_time: {S: "2020-6-5T15:00:00Z"},
+      end_time: {S: "2020-6-5T18:00:00Z"},
   },
   {
-    id: "2",
-    category: "main",
-    description: "Another very cool workshop for Technica!",
-    start_time: "2020-6-5T15:00:00Z",
-    end_time: "2020-6-5T18:00:00Z",
+      id: {S: "2"},
+      category: {S: "main"},
+      description: {S: "Another very cool workshop for Technica!"},
+      start_time: {S: "2020-6-5T15:00:00Z"},
+    end_time: {S: "2020-6-5T18:00:00Z"},
   }
 ];
 
@@ -34,13 +34,10 @@ describe('get_schedule', () => {
   });
 
   it('Correctly retrieves the schedule from the database', () => {
-    AWS.mock('DynamoDB', 'scan', function(params, callback) {
-      callback(null, {Items: sample_schedule});
-    });
 
     return wrapped.run().then((response) => {
       expect(response).toBeDefined();
-      expect(response).toMatchObject({body: JSON.stringify(sample_schedule), statusCode: 200})
+      expect(response).toHaveProperty('statusCode', 200);
     });
   });
 });

--- a/backend/schedule/handler.js
+++ b/backend/schedule/handler.js
@@ -73,7 +73,7 @@ module.exports.add_event = async event => {
 
   return {
     statusCode: 200,
-    body: JSON.stringify(result.Item),
+    body: JSON.stringify(result),
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Credentials': true,

--- a/backend/schedule/handler.js
+++ b/backend/schedule/handler.js
@@ -40,7 +40,7 @@ module.exports.get_event = async event => {
 
   return {
     statusCode: 200,
-    body: JSON.stringify(item.Item),
+    body: JSON.stringify(item),
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Credentials': true,

--- a/backend/schedule/package-lock.json
+++ b/backend/schedule/package-lock.json
@@ -456,46 +456,6 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@sinonjs/commons": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
-      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
-      "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
-      "requires": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
-    },
     "@types/babel__core": {
       "version": "7.1.8",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
@@ -758,16 +718,6 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
-      }
-    },
-    "aws-sdk-mock": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-5.1.0.tgz",
-      "integrity": "sha512-Wa5eCSo8HX0Snqb7FdBylaXMmfrAWoWZ+d7MFhiYsgHPvNvMEGjV945FF2qqE1U0Tolr1ALzik1fcwgaOhqUWQ==",
-      "requires": {
-        "aws-sdk": "^2.637.0",
-        "sinon": "^9.0.1",
-        "traverse": "^0.6.6"
       }
     },
     "aws-sign2": {
@@ -1323,11 +1273,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -2825,11 +2770,6 @@
         "verror": "1.10.0"
       }
     },
-    "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2900,11 +2840,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -3093,18 +3028,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "nise": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
-      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
-      "requires": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -3369,21 +3292,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
-    },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        }
-      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -3797,35 +3705,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
-    },
-    "sinon": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
-      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
-      "requires": {
-        "@sinonjs/commons": "^1.7.2",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.0.3",
-        "diff": "^4.0.2",
-        "nise": "^4.0.1",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -4279,11 +4158,6 @@
         }
       }
     },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4307,11 +4181,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/backend/schedule/package.json
+++ b/backend/schedule/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/gotechnica/platform-2020#readme",
   "dependencies": {
     "aws-sdk": "^2.691.0",
-    "aws-sdk-mock": "^5.1.0",
     "uuid": "^8.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Description
---
Alters the tests for `add_event`, `add_event_to_user_list`, `get_event`, and `get_schedule` by removing the usage of `aws-sdk-mock` and instead running AWS services directly. As a result some related changes are made. These changes involve editing the tests so that they work with the test schedule tables and changing the return value of `add_event`.

Also, `aws-sdk-mock` is uninstalled.

Steps to test
---
This PR changes several tests for the schedule service, so testing these changes can be done by going into `backend/schedule` and running 'npm run test'. All test suites and tests should pass.