### PR TITLE
Enable url shortlinks to track link clicks and redirect to the appropriate page

### DIFF
--- a/backend/schedule/handler.js
+++ b/backend/schedule/handler.js
@@ -316,7 +316,7 @@ module.exports.get_shortlink = async event => {
   const item = await ddb.getItem({
     TableName: process.env.SHORTLINKS_TABLE,
     Key: {
-      id: {
+      shortlink: {
         S: id.toString()
       }
     }
@@ -345,7 +345,8 @@ module.exports.add_shortlink_click = async event => {
     Item: {
       id: {S: id},
       link_id: {S: body["link_id"]},
-      user_id: {S: body["user_id"]}
+      user_id: {S: body["user_id"]},
+      timestamp: {S: new Date().toLocaleString()}
     }
   };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14871,6 +14871,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-cookie": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-cookie/-/tiny-cookie-1.0.1.tgz",
+      "integrity": "sha1-dTeGB5xkKjw9CyrMrWAPjeEZrCo="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15524,6 +15529,14 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         }
+      }
+    },
+    "vue-cookie": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vue-cookie/-/vue-cookie-1.1.4.tgz",
+      "integrity": "sha1-uLRtESvan5Oi9HAXwu1SgtIGT9o=",
+      "requires": {
+        "tiny-cookie": "^1.0"
       }
     },
     "vue-eslint-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "npm i && vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "deploy": "npm run build && vue-cli-service s3-deploy",
@@ -15,6 +15,7 @@
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
     "vue-cli-plugin-s3-deploy": "^4.0.0-rc3",
+    "vue-cookie": "^1.1.4",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0"
   },

--- a/frontend/src/config/general.js
+++ b/frontend/src/config/general.js
@@ -1,8 +1,10 @@
 export default {
   dev: {
     SCHEDULE_BASE_ENDPOINT: 'https://dxz39cp5d0.execute-api.us-east-1.amazonaws.com',
+    SAMPLE_USER_ID: 'SAMPLE_USER_ID'
   },
   testing: {
     SCHEDULE_BASE_ENDPOINT: 'https://dxz39cp5d0.execute-api.us-east-1.amazonaws.com',
+    SAMPLE_USER_ID: 'SAMPLE_USER_ID'
   },
 };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,6 +8,10 @@ Vue.config.productionTip = false;
 // Importing the global css file
 import './assets/global.css'
 
+const VueCookie = require('vue-cookie');
+// Tell Vue to use the plugin
+Vue.use(VueCookie);
+
 new Vue({
   router,
   store,

--- a/frontend/src/mixins/general.js
+++ b/frontend/src/mixins/general.js
@@ -12,12 +12,37 @@ export default {
     },
     processDynamoResponse(rawResponse) {
       return rawResponse.map((item) => {
-        const formattedItem = {};
+        return this.formatDynamoItem(item);
+      });
+    },
+    formatDynamoItem(item) {
+      const formattedItem = {};
         Object.keys(item).map((key) => {
           formattedItem[key] = item[key].S;
         });
-        return formattedItem;
-      });
+      return formattedItem;
     },
+    async performGetRequest(baseUrl, stage, endpoint, params) {
+      try {
+        const result = await Axios.get(`${baseUrl}/${stage}/${endpoint}`, {params});
+        return this.formatDynamoItem(result.data);
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    async performPostRequest(baseUrl, stage, endpoint, params) {
+      try {
+        const result = await Axios.post(`${baseUrl}/${stage}/${endpoint}`, params);
+        return result.data;
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    getUserId() {
+      return this.$cookie.get('userId');
+    },
+    setUserIdCookie(id) {
+      this.$cookie.set('userId', id, 100);
+    }
   },
 };

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -48,6 +48,15 @@ const routes = [
     name: 'Register',
     component: () => import('../views/Register.vue'),
   },
+  {
+    path: '/404',
+    name: '404',
+    component: () => import('../views/404.vue'),
+  },
+  {
+    path: '/:shortlink', 
+    component: () => import('../views/ShortLink.vue')
+  }
 ];
 
 const router = new VueRouter({

--- a/frontend/src/views/404.vue
+++ b/frontend/src/views/404.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="about">
+    <h1>This is a 404 page</h1>
+  </div>
+</template>

--- a/frontend/src/views/ShortLink.vue
+++ b/frontend/src/views/ShortLink.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="about">
+    <h1>This is a shortlink page</h1>
+  </div>
+</template>
+
+<script>
+import generalMixin from '../mixins/general';
+import Config from '../config/general';
+export default {
+  name: 'Shortlink',
+  mixins: [generalMixin],
+  data(){
+    return {
+
+    }
+  },
+  async mounted(){
+    this.setUserIdCookie(Config.dev.SAMPLE_USER_ID);
+    const params = {
+        id: this.$route.params.shortlink
+    }
+    const shortlink = await this.performGetRequest(Config.dev.SCHEDULE_BASE_ENDPOINT, "dev", "get_shortlink", params);
+
+    if(shortlink && shortlink.link) {
+        const postParams = {
+            link_id: shortlink.id,
+            user_id: this.getUserId()
+        }
+        const postResult = await this.performPostRequest(Config.dev.SCHEDULE_BASE_ENDPOINT, "dev", "add_shortlink_click", postParams);
+        window.location = shortlink.link;
+    } else {
+        // redirect to 404
+        this.$router.push('404'); 
+    }
+  }
+};
+</script>

--- a/frontend/src/views/ShortLink.vue
+++ b/frontend/src/views/ShortLink.vue
@@ -27,7 +27,7 @@ export default {
             link_id: shortlink.id,
             user_id: this.getUserId()
         }
-        const postResult = await this.performPostRequest(Config.dev.SCHEDULE_BASE_ENDPOINT, "dev", "add_shortlink_click", postParams);
+        this.performPostRequest(Config.dev.SCHEDULE_BASE_ENDPOINT, "dev", "add_shortlink_click", postParams);
         window.location = shortlink.link;
     } else {
         // redirect to 404

--- a/frontend/src/views/ShortLink.vue
+++ b/frontend/src/views/ShortLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="about">
-    <h1>This is a shortlink page</h1>
+
   </div>
 </template>
 


### PR DESCRIPTION
## Description
Enables our url shortlinks to track link clicks and redirect to the appropriate page, so we can share links like `gotechnica.org/jXj7a` that redirect to zoom meetings and other events. These are special branded links, but they also track link clicks in the database and record which users visit a particular event.

## Steps to test
1. Pull down the branch and run the frontend app locally
2. Go to `http://localhost:8081/TNdJK7` and check it redirects you to `google.com`. It should also log your activity in the DB in the `platform-shortlink-clicks-dev` table