### PR TITLE
Update .gitignores to ignore coverage

### DIFF
--- a/backend/admin/.gitignore
+++ b/backend/admin/.gitignore
@@ -4,3 +4,5 @@ jspm_packages
 
 # Serverless directories
 .serverless
+
+coverage/*

--- a/backend/projects/.gitignore
+++ b/backend/projects/.gitignore
@@ -4,3 +4,5 @@ jspm_packages
 
 # Serverless directories
 .serverless
+
+coverage/*

--- a/backend/users/.gitignore
+++ b/backend/users/.gitignore
@@ -4,3 +4,5 @@ jspm_packages
 
 # Serverless directories
 .serverless
+
+coverage/*


### PR DESCRIPTION
Previously, coverage tests' output was not ignored [(e.g. andrew's commit)](https://github.com/gotechnica/platform-2020/commit/0b61c1a7311d8900ec539e8a3b2065cc4556a41a).

This PR adds that to all backend folders, and removes 1 coverage test folder.