### PR TITLE
Adds activity tracking post requests to several pages

### DIFF
--- a/frontend/src/mixins/general.js
+++ b/frontend/src/mixins/general.js
@@ -91,5 +91,13 @@ export default {
       }
       return 'dev';
     },
+    async activityTracking(actionName) {
+      const env = this.getCurrentEnvironment();
+      const params = {
+        user_id: this.getUserId(),
+        action: actionName,
+      };
+      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
+    },
   },
 };

--- a/frontend/src/views/HelpDesk.vue
+++ b/frontend/src/views/HelpDesk.vue
@@ -55,17 +55,7 @@ export default {
     };
   },
   async mounted() {
-    await this.activityTracking();
-  },
-  methods: {
-    async activityTracking() {
-      const env = this.getCurrentEnvironment();
-      const params = {
-        user_id: this.getUserId(),
-	action: "HELPDESK",
-      };
-      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
-    },
+    await this.activityTracking('HELPDESK');
   },
 };
 </script>

--- a/frontend/src/views/HelpDesk.vue
+++ b/frontend/src/views/HelpDesk.vue
@@ -54,6 +54,19 @@ export default {
       helpDeskLink: Config.shared.SAMPLE_ZOOM_LINK,
     };
   },
+  async mounted() {
+    await this.activityTracking();
+  },
+  methods: {
+    async activityTracking() {
+      const env = this.getCurrentEnvironment();
+      const params = {
+        user_id: this.getUserId(),
+	action: "HELPDESK",
+      };
+      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
+    },
+  },
 };
 </script>
 

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -35,11 +35,22 @@ export default {
     Banner,
   },
   mixins: [generalMixin],
+  async mounted() {
+    await this.activityTracking();
+  },
   methods: {
     initiateOnboardingWalkthrough() {
       const env = this.getCurrentEnvironment();
       // eslint-disable-next-line no-undef
       Intercom('startTour', Config[env].PLATFORM_WALKTHROUGH_ID);
+    },
+    async activityTracking() {
+      const env = this.getCurrentEnvironment();
+      const params = {
+        user_id: this.getUserId(),
+        action: "HOME",
+      };
+      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -36,21 +36,13 @@ export default {
   },
   mixins: [generalMixin],
   async mounted() {
-    await this.activityTracking();
+    await this.activityTracking('HOME');
   },
   methods: {
     initiateOnboardingWalkthrough() {
       const env = this.getCurrentEnvironment();
       // eslint-disable-next-line no-undef
       Intercom('startTour', Config[env].PLATFORM_WALKTHROUGH_ID);
-    },
-    async activityTracking() {
-      const env = this.getCurrentEnvironment();
-      const params = {
-        user_id: this.getUserId(),
-        action: "HOME",
-      };
-      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/RequestMentor.vue
+++ b/frontend/src/views/RequestMentor.vue
@@ -75,7 +75,7 @@ export default {
     };
   },
   async mounted() {
-    await this.activityTracking();
+    await this.activityTracking('REQUEST_MENTOR');
     await this.getMentorRequests();
   },
   methods: {
@@ -110,14 +110,6 @@ export default {
       this.requestTitle = '';
       this.requestTopic = '';
       this.requestDescription = '';
-    },
-    async activityTracking() {
-      const env = this.getCurrentEnvironment();
-      const params = {
-        user_id: this.getUserId(),
-        action: "REQUEST_MENTOR",
-      };
-      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/RequestMentor.vue
+++ b/frontend/src/views/RequestMentor.vue
@@ -75,6 +75,7 @@ export default {
     };
   },
   async mounted() {
+    await this.activityTracking();
     await this.getMentorRequests();
   },
   methods: {
@@ -109,6 +110,14 @@ export default {
       this.requestTitle = '';
       this.requestTopic = '';
       this.requestDescription = '';
+    },
+    async activityTracking() {
+      const env = this.getCurrentEnvironment();
+      const params = {
+        user_id: this.getUserId(),
+        action: "REQUEST_MENTOR",
+      };
+      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/Schedule.vue
+++ b/frontend/src/views/Schedule.vue
@@ -89,7 +89,7 @@ export default {
   },
   async mounted() {
     console.log(process.env.NODE_ENV);
-    await this.activityTracking();
+    await this.activityTracking('SCHEDULE');
     const env = this.getCurrentEnvironment();
     this.events = await this.getData(Config[env].SCHEDULE_BASE_ENDPOINT, env, 'schedule');
     console.log(this.schedule);
@@ -100,14 +100,6 @@ export default {
     },
     selectTitleItem(day) {
       this.selectedDay = day;
-    },
-    async activityTracking() {
-      const env = this.getCurrentEnvironment();
-      const params = {
-        user_id: this.getUserId(),
-        action: "SCHEDULE",
-      };
-      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/Schedule.vue
+++ b/frontend/src/views/Schedule.vue
@@ -89,6 +89,7 @@ export default {
   },
   async mounted() {
     console.log(process.env.NODE_ENV);
+    await this.activityTracking();
     const env = this.getCurrentEnvironment();
     this.events = await this.getData(Config[env].SCHEDULE_BASE_ENDPOINT, env, 'schedule');
     console.log(this.schedule);
@@ -99,6 +100,14 @@ export default {
     },
     selectTitleItem(day) {
       this.selectedDay = day;
+    },
+    async activityTracking() {
+      const env = this.getCurrentEnvironment();
+      const params = {
+        user_id: this.getUserId(),
+        action: "SCHEDULE",
+      };
+      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/Team.vue
+++ b/frontend/src/views/Team.vue
@@ -111,7 +111,7 @@ export default {
     };
   },
   async mounted() {
-    await this.activityTracking();
+    await this.activityTracking('TEAMS');
     await this.getInvitesForHacker();
     await this.getTeam();
     this.dataLoaded = true;
@@ -131,11 +131,7 @@ export default {
           project_submitted: false,
         };
         const createdTeam = await this.performPostRequest(Config[env].TEAMS_BASE_ENDPOINT, env, 'create_team', createTeamPostParams);
-        const activityPostParams = {
-          user_id: this.getUserId(),
-          action: 'TEAM_CREATION',
-      	};
-        await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', activityPostParams);
+        await this.activityTracking('TEAM_CREATION');
         // after creating the new team, join it
         const joinTeamPostParams = {
           team_id: createdTeam.id,
@@ -240,14 +236,6 @@ export default {
       await this.performPostRequest(Config[env].TEAMS_BASE_ENDPOINT, env, 'leave_team', params);
       this.currentTeam = null;
       this.$emit('teamMembershipChanged', false);
-    },
-    async activityTracking() {
-      const env = this.getCurrentEnvironment();
-      const params = {
-        user_id: this.getUserId(),
-        action: 'TEAMS',
-      };
-      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };

--- a/frontend/src/views/Team.vue
+++ b/frontend/src/views/Team.vue
@@ -131,9 +131,9 @@ export default {
           project_submitted: false,
         };
         const createdTeam = await this.performPostRequest(Config[env].TEAMS_BASE_ENDPOINT, env, 'create_team', createTeamPostParams);
-	const activityPostParams = {
+        const activityPostParams = {
           user_id: this.getUserId(),
-	  action: "TEAM_CREATION",
+          action: 'TEAM_CREATION',
       	};
         await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', activityPostParams);
         // after creating the new team, join it
@@ -245,7 +245,7 @@ export default {
       const env = this.getCurrentEnvironment();
       const params = {
         user_id: this.getUserId(),
-	action: "TEAMS",
+        action: 'TEAMS',
       };
       await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },

--- a/frontend/src/views/Team.vue
+++ b/frontend/src/views/Team.vue
@@ -111,6 +111,7 @@ export default {
     };
   },
   async mounted() {
+    await this.activityTracking();
     await this.getInvitesForHacker();
     await this.getTeam();
     this.dataLoaded = true;
@@ -130,6 +131,11 @@ export default {
           project_submitted: false,
         };
         const createdTeam = await this.performPostRequest(Config[env].TEAMS_BASE_ENDPOINT, env, 'create_team', createTeamPostParams);
+	const activityPostParams = {
+          user_id: this.getUserId(),
+	  action: "TEAM_CREATION",
+      	};
+        await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', activityPostParams);
         // after creating the new team, join it
         const joinTeamPostParams = {
           team_id: createdTeam.id,
@@ -234,6 +240,14 @@ export default {
       await this.performPostRequest(Config[env].TEAMS_BASE_ENDPOINT, env, 'leave_team', params);
       this.currentTeam = null;
       this.$emit('teamMembershipChanged', false);
+    },
+    async activityTracking() {
+      const env = this.getCurrentEnvironment();
+      const params = {
+        user_id: this.getUserId(),
+	action: "TEAMS",
+      };
+      await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },
   },
 };


### PR DESCRIPTION
Description
---

Adds post requests to several functions on the frontend (mostly page loading). These post requests add entries to the `platform-<stage>-activity` wherein the entry shows the `user_id` of the user accessing the site as well as an `action` showing what activity was performed. The table below shows a breakdown of the changes made.

|  Action being tracked |  Page with request |  `action` parameter |
|---|---|---|
|  Home page load |  Home.vue | `HOME` |
|  Schedule page load |  Schedule.vue | `SCHEDULE` |
|  Teams page load | Team.vue |  `TEAMS` |
|  Request Mentor page load |  RequestMentor.vue | `REQUEST_MENTOR` |
|  Helpdesk page load | HelpDesk.vue | `HELPDESK` |
| Team Creation | Team.vue | `TEAM_CREATION` |

Steps to Test
---

Run `npm run serve` and access the pages mentioned above, as well as create a team. You should see the corresponding items appear in `platform-dev-activity`
