### PR TITLE
Adds slack messages for basic activity tracking

### DIFF
--- a/backend/users/handler.js
+++ b/backend/users/handler.js
@@ -581,9 +581,15 @@ module.exports.track_user_activity = withSentry(async (action) => {
   const webhookUrl = webhookJSON.PLATFORM_ACTVITY_SLACK_WEBHOOK;
   const webhook = new IncomingWebhook(webhookUrl);
   if (process.env.STAGE !== TESTING_STAGE) {
-    await webhook.send({
-      text: `TEMP: User ${body.user_id} has performed ${body.action} on ${process.env.STAGE}`,
-    });
+    if (body.action == 'TEAM_CREATION') {
+      await webhook.send({
+        text: `${body.user_name} performed ${body.action} on ${process.env.STAGE}`,
+      });
+    } else {
+      await webhook.send({
+        text: `${body.user_name} visited page ${body.action} on ${process.env.STAGE}`,
+      });
+    }
   }
     
   return {

--- a/frontend/src/mixins/general.js
+++ b/frontend/src/mixins/general.js
@@ -96,6 +96,7 @@ export default {
       const params = {
         user_id: this.getUserId(),
         action: actionName,
+        user_name: this.getUserName(),
       };
       await this.performPostRequest(Config[env].USERS_BASE_ENDPOINT, env, 'track_user_activity', params);
     },


### PR DESCRIPTION
Description
---
Adds pushes to the slack channel `platform-activity` whenever the `track_user_activity` backend endpoint is called. When a user performs an activity that is tracked, a message is sent to the slack channel reflecting the user, the activity, and the stage.

Steps to Test
---
Go on the website (after ensuring the users service has been deployed on the stage you are on) and perform any of the activities described in #145 and look in the `platform_activity` slack channel.